### PR TITLE
Fix compilation error caused by change in org.eclipse.jdt.core 3.37.0

### DIFF
--- a/org.eclipse.eclemma.core/src/org/eclipse/eclemma/internal/core/SessionExporter.java
+++ b/org.eclipse.eclemma.core/src/org/eclipse/eclemma/internal/core/SessionExporter.java
@@ -170,8 +170,8 @@ public class SessionExporter implements ISessionExporter {
 
     public AbstractSourceFileLocator(IPackageFragmentRoot root) {
       this.root = root;
-      final Map<?, ?> options = root.getJavaProject().getOptions(true);
-      this.tabWidth = IndentManipulation.getTabWidth(options);
+      this.tabWidth = IndentManipulation
+          .getTabWidth(root.getJavaProject().getOptions(true));
     }
 
     public final int getTabWidth() {


### PR DESCRIPTION
Prior to this change execution of

```
mvn compile -Pe4.31
```

leads to

```
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-compiler-plugin:3.0.5:compile (default-compile) on project org.eclipse.eclemma.core: Compilation failure: Compilation failure:
[ERROR] org.eclipse.eclemma.core/src/org/eclipse/eclemma/internal/core/SessionExporter.java:[174]
[ERROR]         this.tabWidth = IndentManipulation.getTabWidth(options);
[ERROR]                                            ^^^^^^^^^^^
[ERROR] The method getTabWidth(Map<String,String>) in the type IndentManipulation is not applicable for the arguments (Map<capture#1-of ?,capture#2-of ?>)
```

which is caused by change in
https://github.com/eclipse-jdt/eclipse.jdt.core/commit/4556ac22b87bd69828fed9fbcf8ce24c24fad2ec