### PR TITLE
Provide full license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -258,3 +258,20 @@ estoppel or otherwise. All rights in the Program not expressly granted
 under this Agreement are reserved. Nothing in this Agreement is intended
 to be enforceable by any entity that is not a Contributor or Recipient.
 No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set forth
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.


### PR DESCRIPTION
According to https://www.eclipse.org/legal/epl-2.0/faq.php#h.aofuc4dbllpj

> ### 2.11. Can I remove Exhibit A from the license text if I do not intend to enable a Secondary License?
> No. Exhibit A forms part of the License Agreement and thus cannot be removed. Exhibit A is provided in order to allow the source code to be made available under a secondary license(s). The EPL-2.0 stipulates applicable secondary licenses are the GNU General Public License, Version 2.0, or any later versions of that license, including any exceptions or additional permissions as identified by the initial Contributor.
>
> If you do not wish to enable any Secondary Licenses for content that you create, then you can basically ignore the Exhibit A. If you do want to enable one or more Secondary Licenses, then you should include a copy of the notice statement in Exhibit A in your file header copyright notices, and/or any additional notices you provide to your downstream adopters.

Additionally it will be recognized by GitHub, i.e.
before this change

<img width="311" alt="before" src="https://github.com/eclipse-eclemma/eclemma/assets/138671/ef3c661a-02fe-40eb-8fb4-c4769b9cb609">

and after

<img width="311" alt="after" src="https://github.com/eclipse-eclemma/eclemma/assets/138671/23032adb-0f47-4c32-910a-79eaa1b220ac">
