### PR TITLE
Fix failure of tests caused by change in org.eclipse.jdt.core 3.39.0

### DIFF
--- a/org.eclipse.eclemma.core.test/src/org/eclipse/eclemma/core/JavaProjectKit.java
+++ b/org.eclipse.eclemma.core.test/src/org/eclipse/eclemma/core/JavaProjectKit.java
@@ -46,6 +46,7 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.launching.JavaRuntime;
+import org.osgi.framework.Version;
 
 import org.eclipse.eclemma.internal.core.EclEmmaCorePlugin;
 
@@ -53,6 +54,9 @@ import org.eclipse.eclemma.internal.core.EclEmmaCorePlugin;
  * Utility class to setup Java projects programmatically.
  */
 public class JavaProjectKit {
+
+  private static final boolean JDT_3_39 = JavaCore.getPlugin().getBundle()
+      .getVersion().compareTo(new Version("3.39.0")) >= 0;
 
   private static final String DEFAULT_PROJECT_NAME = "UnitTestProject";
 
@@ -80,9 +84,12 @@ public class JavaProjectKit {
     addClassPathEntry(JavaRuntime.getDefaultJREContainerEntry());
   }
 
-  public void enableJava5() {
-    javaProject.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
-    javaProject.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
+  public void enableJava() {
+    final String lowestSupportedJavaVersion = JDT_3_39 ? JavaCore.VERSION_1_8
+        : JavaCore.VERSION_1_5;
+    javaProject.setOption(JavaCore.COMPILER_COMPLIANCE,
+        lowestSupportedJavaVersion);
+    javaProject.setOption(JavaCore.COMPILER_SOURCE, lowestSupportedJavaVersion);
   }
 
   public IFolder setDefaultOutputLocation(String foldername)

--- a/org.eclipse.eclemma.core.test/src/org/eclipse/eclemma/internal/core/analysis/BinarySignatureResolverTest.java
+++ b/org.eclipse.eclemma.core.test/src/org/eclipse/eclemma/internal/core/analysis/BinarySignatureResolverTest.java
@@ -33,7 +33,7 @@ public class BinarySignatureResolverTest extends SignatureResolverTestBase {
   @Before
   public void setup() throws Exception {
     javaProject = new JavaProjectKit();
-    javaProject.enableJava5();
+    javaProject.enableJava();
     final IPackageFragmentRoot root = javaProject.createJAR(
         "testdata/bin/signatureresolver.jar", "/signatureresolver.jar",
         new Path("/UnitTestProject/signatureresolver.jar"), null);

--- a/org.eclipse.eclemma.core.test/src/org/eclipse/eclemma/internal/core/analysis/MethodLocatorTest.java
+++ b/org.eclipse.eclemma.core.test/src/org/eclipse/eclemma/internal/core/analysis/MethodLocatorTest.java
@@ -44,7 +44,7 @@ public class MethodLocatorTest {
   @Before
   public void setup() throws Exception {
     javaProject = new JavaProjectKit();
-    javaProject.enableJava5();
+    javaProject.enableJava();
     final IPackageFragmentRoot root = javaProject.createSourceFolder("src");
     final ICompilationUnit compilationUnit = javaProject.createCompilationUnit(
         root, "testdata/src", "methodlocator/Samples.java");

--- a/org.eclipse.eclemma.core.test/src/org/eclipse/eclemma/internal/core/analysis/SourceSignatureResolverTest.java
+++ b/org.eclipse.eclemma.core.test/src/org/eclipse/eclemma/internal/core/analysis/SourceSignatureResolverTest.java
@@ -33,7 +33,7 @@ public class SourceSignatureResolverTest extends SignatureResolverTestBase {
   @Before
   public void setup() throws Exception {
     javaProject = new JavaProjectKit();
-    javaProject.enableJava5();
+    javaProject.enableJava();
     final IPackageFragmentRoot root = javaProject.createSourceFolder("src");
     final ICompilationUnit compilationUnit = javaProject.createCompilationUnit(
         root, "testdata/src", "signatureresolver/Samples.java");

--- a/org.eclipse.eclemma.ui.test/src/org/eclipse/eclemma/ui/DumpExecutionDataTest.java
+++ b/org.eclipse.eclemma.ui.test/src/org/eclipse/eclemma/ui/DumpExecutionDataTest.java
@@ -54,7 +54,7 @@ public class DumpExecutionDataTest {
     openCoverageView();
 
     JavaProjectKit project = new JavaProjectKit();
-    project.enableJava5();
+    project.enableJava();
     final IPackageFragmentRoot root = project.createSourceFolder();
     final IPackageFragment fragment = project.createPackage(root, "example");
     project.createCompilationUnit(fragment, "Example.java", "package example;" //

--- a/org.eclipse.eclemma.ui.test/src/org/eclipse/eclemma/ui/JavaProjectKit.java
+++ b/org.eclipse.eclemma.ui.test/src/org/eclipse/eclemma/ui/JavaProjectKit.java
@@ -37,6 +37,7 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.launching.JavaRuntime;
+import org.osgi.framework.Version;
 
 /**
  * Utility class to setup Java projects programmatically.
@@ -45,6 +46,9 @@ import org.eclipse.jdt.launching.JavaRuntime;
  * org.eclipse.eclemma.core.test
  */
 public class JavaProjectKit {
+
+  private static final boolean JDT_3_39 = JavaCore.getPlugin().getBundle()
+      .getVersion().compareTo(new Version("3.39.0")) >= 0;
 
   private static final String DEFAULT_PROJECT_NAME = "UnitTestProject";
 
@@ -72,9 +76,12 @@ public class JavaProjectKit {
     addClassPathEntry(JavaRuntime.getDefaultJREContainerEntry());
   }
 
-  public void enableJava5() {
-    javaProject.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
-    javaProject.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
+  public void enableJava() {
+    final String lowestSupportedJavaVersion = JDT_3_39 ? JavaCore.VERSION_1_8
+        : JavaCore.VERSION_1_5;
+    javaProject.setOption(JavaCore.COMPILER_COMPLIANCE,
+        lowestSupportedJavaVersion);
+    javaProject.setOption(JavaCore.COMPILER_SOURCE, lowestSupportedJavaVersion);
   }
 
   public IPackageFragmentRoot createSourceFolder() throws CoreException {


### PR DESCRIPTION
Prior to this change execution of

    mvn verify -Pe4.33 -DskipUITests=false

leads to

    java.lang.AssertionError: Compiling for Java version '1.5' is no longer supported. Minimal supported version is '1.8'
            at org.eclipse.eclemma.internal.core.analysis.SourceSignatureResolverTest.setup(SourceSignatureResolverTest.java:41)

which is caused by change in
https://github.com/eclipse-jdt/eclipse.jdt.core/commit/08978b8d11524ae820c806511ff454dd1630df1f