### PR TITLE
Dependabot should use Eclipse Maven repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ registries:
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    registries: "*"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
This was forgotten in commit 5d2876d296ea92844e4a47bae0b2401a8b8b5187 and without this change it fails with following error:

    The property '#/registries' includes the "eclipse" registry which is not used in any of the configurations